### PR TITLE
fix: TextWidget always display the component name

### DIFF
--- a/packages/react/src/widgets/TextWidget/index.tsx
+++ b/packages/react/src/widgets/TextWidget/index.tsx
@@ -35,7 +35,7 @@ export const TextWidget: React.FC<ITextWidgetProps> = observer((props) => {
   }
   const token = takeToken()
   const message =
-    takeMessage(token) || takeMessage(props.token) || props.defaultMessage
+    takeMessage(token) || takeMessage(props.token)
   if (message) return message
   return <Fragment>{props.children}</Fragment>
 })


### PR DESCRIPTION
When the component componentName is all the same, the outline tree and drag and drop and node title are all the same, not easy to observe, clone formily project run playground can be reproduced, modified to display the title of the component normally

Before submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/designable/blob/main/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `main`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.
