### PR TITLE
fix(setters): problem about reactions configure

### DIFF
--- a/formily/setters/src/components/ReactionsSetter/index.tsx
+++ b/formily/setters/src/components/ReactionsSetter/index.tsx
@@ -320,6 +320,7 @@ export const ReactionsSetter: React.FC<IReactionsSetterProps> = (props) => {
                               const property = field
                                 .query('.property')
                                 .get('inputValues')
+                              property[0] = property[0] ?? 'value'
                               field.query('.source').take((source) => {
                                 if (isVoidField(source)) return
                                 if (source.value) {


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [ ] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/designable/blob/main/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [ ] Fork the repo and create your branch from `main`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

## What have you changed?
After the reactions configure selects the source field for the first time, the field attribute is filled with "value" by default, but the variable type is not updated in time.