### PR TITLE
feat(react-settings-form): add scope parameter dependency

### DIFF
--- a/packages/react-settings-form/src/SettingsForm.tsx
+++ b/packages/react-settings-form/src/SettingsForm.tsx
@@ -50,7 +50,7 @@ export const SettingsForm: React.FC<ISettingFormProps> = observer(
           props.effects?.(form)
         },
       })
-    }, [node, node?.props, schema, operation, isEmpty])
+    }, [node, node?.props, schema, operation, isEmpty, props?.scope])
 
     const render = () => {
       if (!isEmpty) {


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/designable/blob/main/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `main`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

![image](https://user-images.githubusercontent.com/22790863/135216106-f87fb653-1d0d-42a9-ae92-556e45135686.png)

![image](https://user-images.githubusercontent.com/22790863/135218885-69913817-ce3c-43a7-b4ac-b324ccf6a733.png)

 Using [i18n's](https://react.i18next.com/) t function in the Schema file, as shown above, and then passing it through the scope parameter on the SettingForm component, we found that it didn't work, but by looking at the SettingForm source code, we only need to add the props?.scope parameter dependency and it worked. 
