### PR TITLE
feat(formily-setters): add config to DataSourceSetter 

### DIFF
--- a/formily/setters/src/components/DataSourceSetter/DataSettingPanel.tsx
+++ b/formily/setters/src/components/DataSourceSetter/DataSettingPanel.tsx
@@ -9,7 +9,7 @@ import { ValueInput } from '@designable/react-settings-form'
 import { usePrefix, TextWidget } from '@designable/react'
 import { Header } from './Header'
 import { traverseTree } from './shared'
-import { ITreeDataSource, IKeyValuePairProps } from './types'
+import { ITreeDataSource } from './types'
 import './styles.less'
 
 const SchemaField = createSchemaField({
@@ -24,7 +24,6 @@ const SchemaField = createSchemaField({
 export interface IDataSettingPanelProps {
   treeDataSource: ITreeDataSource
   allowExtendOption?: boolean
-  defaultKeyValuePairs?: IKeyValuePairProps[]
   effects?: (form: FormCore<any>) => void
 }
 

--- a/formily/setters/src/components/DataSourceSetter/DataSettingPanel.tsx
+++ b/formily/setters/src/components/DataSourceSetter/DataSettingPanel.tsx
@@ -41,7 +41,7 @@ export const DataSettingPanel: React.FC<IDataSettingPanelProps> = observer(
       })
       return createForm({
         values,
-        effects: effects
+        effects: effects,
       })
     }, [
       props.treeDataSource.selectedKey,

--- a/formily/setters/src/components/DataSourceSetter/DataSettingPanel.tsx
+++ b/formily/setters/src/components/DataSourceSetter/DataSettingPanel.tsx
@@ -2,14 +2,14 @@ import React, { useMemo, Fragment } from 'react'
 import { Button } from 'antd'
 import { PlusOutlined } from '@ant-design/icons'
 import { ArrayItems, Form, Input, FormItem } from '@formily/antd'
-import { createForm } from '@formily/core'
+import { createForm, Form as FormCore } from '@formily/core'
 import { observer } from '@formily/reactive-react'
 import { createSchemaField } from '@formily/react'
 import { ValueInput } from '@designable/react-settings-form'
 import { usePrefix, TextWidget } from '@designable/react'
 import { Header } from './Header'
 import { traverseTree } from './shared'
-import { ITreeDataSource } from './types'
+import { ITreeDataSource, IKeyValuePairProps } from './types'
 import './styles.less'
 
 const SchemaField = createSchemaField({
@@ -23,10 +23,14 @@ const SchemaField = createSchemaField({
 
 export interface IDataSettingPanelProps {
   treeDataSource: ITreeDataSource
+  allowExtendOption?: boolean
+  defaultKeyValuePairs?: IKeyValuePairProps[]
+  effects?: (form: FormCore<any>) => void
 }
 
 export const DataSettingPanel: React.FC<IDataSettingPanelProps> = observer(
   (props) => {
+    const { allowExtendOption, effects } = props
     const prefix = usePrefix('data-source-setter')
     const form = useMemo(() => {
       let values: any
@@ -37,6 +41,7 @@ export const DataSettingPanel: React.FC<IDataSettingPanelProps> = observer(
       })
       return createForm({
         values,
+        effects: effects
       })
     }, [
       props.treeDataSource.selectedKey,
@@ -63,17 +68,19 @@ export const DataSettingPanel: React.FC<IDataSettingPanelProps> = observer(
             <TextWidget token="SettingComponents.DataSourceSetter.nodeProperty" />
           }
           extra={
-            <Button
-              type="text"
-              onClick={() => {
-                form.setFieldState('map', (state) => {
-                  state.value.push({})
-                })
-              }}
-              icon={<PlusOutlined />}
-            >
-              <TextWidget token="SettingComponents.DataSourceSetter.addKeyValuePair" />
-            </Button>
+            allowExtendOption ? (
+              <Button
+                type="text"
+                onClick={() => {
+                  form.setFieldState('map', (state) => {
+                    state.value.push({})
+                  })
+                }}
+                icon={<PlusOutlined />}
+              >
+                <TextWidget token="SettingComponents.DataSourceSetter.addKeyValuePair" />
+              </Button>
+            ) : null
           }
         />
         <div className={`${prefix + '-layout-item-content'}`}>
@@ -89,6 +96,7 @@ export const DataSettingPanel: React.FC<IDataSettingPanelProps> = observer(
                       <TextWidget token="SettingComponents.DataSourceSetter.label" />
                     }
                     x-decorator="FormItem"
+                    x-disabled={!allowExtendOption}
                     name="label"
                     x-component="Input"
                   />
@@ -102,6 +110,7 @@ export const DataSettingPanel: React.FC<IDataSettingPanelProps> = observer(
                   />
                   <SchemaField.Void
                     x-component="ArrayItems.Remove"
+                    x-visible={allowExtendOption}
                     x-component-props={{
                       style: {
                         margin: 5,

--- a/formily/setters/src/components/DataSourceSetter/TreePanel.tsx
+++ b/formily/setters/src/components/DataSourceSetter/TreePanel.tsx
@@ -11,7 +11,7 @@ import './styles.less'
 import { GlobalRegistry } from '@designable/core'
 
 const limitTreeDrag = ({ dropPosition }) => {
-  if(dropPosition === 0) {
+  if (dropPosition === 0) {
     return false
   }
   return true
@@ -86,12 +86,14 @@ export const TreePanel: React.FC<ITreePanelProps> = observer((props) => {
             onClick={() => {
               const uuid = uid()
               const dataSource = props.treeDataSource.dataSource
-              const initialKeyValuePairs = props.defaultKeyValuePairs?.map(pair => {
-                return {
-                  label: pair.labeKey,
-                  value: null,
+              const initialKeyValuePairs = props.defaultKeyValuePairs?.map(
+                (pair) => {
+                  return {
+                    label: pair.key,
+                    value: null,
+                  }
                 }
-              }) || [
+              ) || [
                 {
                   label: 'label',
                   value: `${GlobalRegistry.getDesignerMessage(

--- a/formily/setters/src/components/DataSourceSetter/TreePanel.tsx
+++ b/formily/setters/src/components/DataSourceSetter/TreePanel.tsx
@@ -6,7 +6,7 @@ import { usePrefix, TextWidget, IconWidget } from '@designable/react'
 import { Title } from './Title'
 import { Header } from './Header'
 import { traverseTree } from './shared'
-import { ITreeDataSource, INodeItem, IKeyValuePairProps } from './types'
+import { ITreeDataSource, INodeItem } from './types'
 import './styles.less'
 import { GlobalRegistry } from '@designable/core'
 
@@ -20,7 +20,10 @@ const limitTreeDrag = ({ dropPosition }) => {
 export interface ITreePanelProps {
   treeDataSource: ITreeDataSource
   allowTree: boolean
-  defaultKeyValuePairs: IKeyValuePairProps[]
+  defaultOptionValue: {
+    label: string
+    value: any
+  }[]
 }
 
 export const TreePanel: React.FC<ITreePanelProps> = observer((props) => {
@@ -86,14 +89,7 @@ export const TreePanel: React.FC<ITreePanelProps> = observer((props) => {
             onClick={() => {
               const uuid = uid()
               const dataSource = props.treeDataSource.dataSource
-              const initialKeyValuePairs = props.defaultKeyValuePairs?.map(
-                (pair) => {
-                  return {
-                    label: pair.key,
-                    value: null,
-                  }
-                }
-              ) || [
+              const initialKeyValuePairs = props.defaultOptionValue || [
                 {
                   label: 'label',
                   value: `${GlobalRegistry.getDesignerMessage(

--- a/formily/setters/src/components/DataSourceSetter/TreePanel.tsx
+++ b/formily/setters/src/components/DataSourceSetter/TreePanel.tsx
@@ -6,12 +6,21 @@ import { usePrefix, TextWidget, IconWidget } from '@designable/react'
 import { Title } from './Title'
 import { Header } from './Header'
 import { traverseTree } from './shared'
-import { ITreeDataSource, INodeItem } from './types'
+import { ITreeDataSource, INodeItem, IKeyValuePairProps } from './types'
 import './styles.less'
 import { GlobalRegistry } from '@designable/core'
 
+const limitTreeDrag = ({ dropPosition }) => {
+  if(dropPosition === 0) {
+    return false
+  }
+  return true
+}
+
 export interface ITreePanelProps {
   treeDataSource: ITreeDataSource
+  allowTree: boolean
+  defaultKeyValuePairs: IKeyValuePairProps[]
 }
 
 export const TreePanel: React.FC<ITreePanelProps> = observer((props) => {
@@ -77,18 +86,24 @@ export const TreePanel: React.FC<ITreePanelProps> = observer((props) => {
             onClick={() => {
               const uuid = uid()
               const dataSource = props.treeDataSource.dataSource
+              const initialKeyValuePairs = props.defaultKeyValuePairs?.map(pair => {
+                return {
+                  label: pair.labeKey,
+                  value: null,
+                }
+              }) || [
+                {
+                  label: 'label',
+                  value: `${GlobalRegistry.getDesignerMessage(
+                    `SettingComponents.DataSourceSetter.item`
+                  )} ${dataSource.length + 1}`,
+                },
+                { label: 'value', value: uuid },
+              ]
               props.treeDataSource.dataSource = dataSource.concat({
                 key: uuid,
                 duplicateKey: uuid,
-                map: [
-                  {
-                    label: 'label',
-                    value: `${GlobalRegistry.getDesignerMessage(
-                      `SettingComponents.DataSourceSetter.item`
-                    )} ${dataSource.length + 1}`,
-                  },
-                  { label: 'value', value: uuid },
-                ],
+                map: initialKeyValuePairs,
                 children: [],
               })
             }}
@@ -101,7 +116,8 @@ export const TreePanel: React.FC<ITreePanelProps> = observer((props) => {
       <div className={`${prefix + '-layout-item-content'}`}>
         <Tree
           blockNode
-          draggable
+          draggable={true}
+          allowDrop={props.allowTree ? null : limitTreeDrag}
           defaultExpandAll
           defaultExpandParent
           autoExpandParent

--- a/formily/setters/src/components/DataSourceSetter/index.tsx
+++ b/formily/setters/src/components/DataSourceSetter/index.tsx
@@ -20,6 +20,7 @@ export interface IDataSourceSetterProps {
   defaultKeyValuePairs?: IKeyValuePairProps[]
   effects?: (form: Form<any>) => void
 }
+
 export const DataSourceSetter: React.FC<IDataSourceSetterProps> = observer(
   (props) => {
     const {

--- a/formily/setters/src/components/DataSourceSetter/index.tsx
+++ b/formily/setters/src/components/DataSourceSetter/index.tsx
@@ -1,24 +1,36 @@
 import React, { Fragment, useMemo, useState } from 'react'
 import cls from 'classnames'
 import { Modal, Button } from 'antd'
+import { Form } from '@formily/core'
 import { observable } from '@formily/reactive'
 import { observer } from '@formily/reactive-react'
 import { usePrefix, useTheme, TextWidget } from '@designable/react'
 import { DataSettingPanel } from './DataSettingPanel'
 import { TreePanel } from './TreePanel'
 import { transformDataToValue, transformValueToData } from './shared'
-import { IDataSourceItem, ITreeDataSource } from './types'
+import { IDataSourceItem, ITreeDataSource, IKeyValuePairProps } from './types'
 import './styles.less'
-
 export interface IDataSourceSetterProps {
   className?: string
   style?: React.CSSProperties
   onChange: (dataSource: IDataSourceItem[]) => void
   value: IDataSourceItem[]
+  allowTree?: boolean
+  allowExtendOption?: boolean
+  defaultKeyValuePairs?: IKeyValuePairProps[]
+  effects?: (form: Form<any>) => void
 }
 export const DataSourceSetter: React.FC<IDataSourceSetterProps> = observer(
   (props) => {
-    const { className, value = [], onChange } = props
+    const {
+      className,
+      value = [],
+      onChange,
+      allowTree = true,
+      allowExtendOption = false,
+      defaultKeyValuePairs,
+      effects = () => {},
+    } = props
     const theme = useTheme()
     const prefix = usePrefix('data-source-setter')
     const [modalVisible, setModalVisible] = useState(false)
@@ -58,11 +70,17 @@ export const DataSourceSetter: React.FC<IDataSourceSetterProps> = observer(
             }`}
           >
             <div className={`${prefix + '-layout-item left'}`}>
-              <TreePanel treeDataSource={treeDataSource}></TreePanel>
+              <TreePanel
+                defaultKeyValuePairs={defaultKeyValuePairs}
+                allowTree={allowTree}
+                treeDataSource={treeDataSource}
+              ></TreePanel>
             </div>
             <div className={`${prefix + '-layout-item right'}`}>
               <DataSettingPanel
+                allowExtendOption={allowExtendOption}
                 treeDataSource={treeDataSource}
+                effects={effects}
               ></DataSettingPanel>
             </div>
           </div>

--- a/formily/setters/src/components/DataSourceSetter/index.tsx
+++ b/formily/setters/src/components/DataSourceSetter/index.tsx
@@ -8,7 +8,7 @@ import { usePrefix, useTheme, TextWidget } from '@designable/react'
 import { DataSettingPanel } from './DataSettingPanel'
 import { TreePanel } from './TreePanel'
 import { transformDataToValue, transformValueToData } from './shared'
-import { IDataSourceItem, ITreeDataSource, IKeyValuePairProps } from './types'
+import { IDataSourceItem, ITreeDataSource } from './types'
 import './styles.less'
 export interface IDataSourceSetterProps {
   className?: string
@@ -17,7 +17,10 @@ export interface IDataSourceSetterProps {
   value: IDataSourceItem[]
   allowTree?: boolean
   allowExtendOption?: boolean
-  defaultKeyValuePairs?: IKeyValuePairProps[]
+  defaultOptionValue?: {
+    label: string
+    value: any
+  }[]
   effects?: (form: Form<any>) => void
 }
 
@@ -29,7 +32,7 @@ export const DataSourceSetter: React.FC<IDataSourceSetterProps> = observer(
       onChange,
       allowTree = true,
       allowExtendOption = true,
-      defaultKeyValuePairs,
+      defaultOptionValue,
       effects = () => {},
     } = props
     const theme = useTheme()
@@ -72,7 +75,7 @@ export const DataSourceSetter: React.FC<IDataSourceSetterProps> = observer(
           >
             <div className={`${prefix + '-layout-item left'}`}>
               <TreePanel
-                defaultKeyValuePairs={defaultKeyValuePairs}
+                defaultOptionValue={defaultOptionValue}
                 allowTree={allowTree}
                 treeDataSource={treeDataSource}
               ></TreePanel>

--- a/formily/setters/src/components/DataSourceSetter/index.tsx
+++ b/formily/setters/src/components/DataSourceSetter/index.tsx
@@ -27,7 +27,7 @@ export const DataSourceSetter: React.FC<IDataSourceSetterProps> = observer(
       value = [],
       onChange,
       allowTree = true,
-      allowExtendOption = false,
+      allowExtendOption = true,
       defaultKeyValuePairs,
       effects = () => {},
     } = props

--- a/formily/setters/src/components/DataSourceSetter/types.ts
+++ b/formily/setters/src/components/DataSourceSetter/types.ts
@@ -15,3 +15,7 @@ export interface ITreeDataSource {
   dataSource: INodeItem[]
   selectedKey: string
 }
+
+export interface IKeyValuePairProps {
+  labeKey: string,
+}

--- a/formily/setters/src/components/DataSourceSetter/types.ts
+++ b/formily/setters/src/components/DataSourceSetter/types.ts
@@ -17,5 +17,5 @@ export interface ITreeDataSource {
 }
 
 export interface IKeyValuePairProps {
-  labeKey: string,
+  key: string
 }

--- a/formily/setters/src/components/DataSourceSetter/types.ts
+++ b/formily/setters/src/components/DataSourceSetter/types.ts
@@ -15,7 +15,3 @@ export interface ITreeDataSource {
   dataSource: INodeItem[]
   selectedKey: string
 }
-
-export interface IKeyValuePairProps {
-  key: string
-}


### PR DESCRIPTION
```typescript
interface IDataSourceSetterProps {
  className?: string
  style?: React.CSSProperties
  onChange: (dataSource: IDataSourceItem[]) => void
  value: IDataSourceItem[]
  allowTree?: boolean // 是否开启树形节点 默认开启
  allowExtendOption?: boolean // 是否运行开启扩展属性 默认开启
  defaultKeyValuePairs?: IKeyValuePairProps[] //  默认键值对
  effects?: (form: Form<any>) => void // 运行自定义effects
}
```