### PR TITLE
fix(formily-setters): fix duplicate key warn in ReactionSetter

### DIFF
--- a/formily/setters/src/components/ReactionsSetter/properties.ts
+++ b/formily/setters/src/components/ReactionsSetter/properties.ts
@@ -43,7 +43,7 @@ export const FieldProperties = [
     helpCode: ComponentPropsHelper,
   },
   {
-    key: 'componentProps',
+    key: 'decoratorProps',
     token: 'decoratorProps',
     type: 'object',
     helpCode: DecoratorPropsHelper,


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/designable/blob/main/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `main`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

#### Fix warning like this:
![image](https://user-images.githubusercontent.com/15569753/142439000-eea84335-1c57-4b80-a02c-bcf629e856df.png)

