### PR TITLE
fix(react): remove the cleanup of ShadowSVG's effect

### DIFF
--- a/packages/react/src/widgets/IconWidget/index.tsx
+++ b/packages/react/src/widgets/IconWidget/index.tsx
@@ -133,12 +133,6 @@ IconWidget.ShadowSVG = (props) => {
       })
       root.innerHTML = `<svg viewBox="0 0 1024 1024" style="width:${width};height:${height}">${props.content}</svg>`
     }
-    return () => {
-      if (!ref.current) return
-      ref.current.attachShadow({
-        mode: 'closed',
-      })
-    }
   }, [])
   return <div ref={ref}></div>
 }


### PR DESCRIPTION
我在将 designable 用在 umi 项目中发现会报错 `Uncaught DOMException: Failed to execute 'attachShadow' on 'Element': Shadow root cannot be created on a host which already hosts a shadow tree.`，调查了一下发现在已经 `attachShadow` 的元素上再次调用 `attachShadow` 会报错这个错误。

我试了一下 [普通情况](https://codepen.io/1010543618/pen/jOGqezE)  无法复现这个问题，因为 `ref.current` 总是 `null`.

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/designable/blob/main/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `main`.
- [ ] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.
