### PR TITLE
fix(playground): fix compatibility

### DIFF
--- a/formily/antd/playground/main.tsx
+++ b/formily/antd/playground/main.tsx
@@ -172,7 +172,7 @@ const App = () => {
                 use={['DESIGNABLE', 'JSONTREE', 'MARKUP', 'PREVIEW']}
               />
             </ToolbarPanel>
-            <ViewportPanel>
+            <ViewportPanel style={{ height: '100%' }}>
               <ViewPanel type="DESIGNABLE">
                 {() => (
                   <ComponentTreeWidget

--- a/formily/next/playground/main.tsx
+++ b/formily/next/playground/main.tsx
@@ -168,7 +168,7 @@ const App = () => {
                 use={['DESIGNABLE', 'JSONTREE', 'MARKUP', 'PREVIEW']}
               />
             </ToolbarPanel>
-            <ViewportPanel>
+            <ViewportPanel style={{ height: '100%' }}>
               <ViewPanel type="DESIGNABLE">
                 {() => (
                   <ComponentTreeWidget


### PR DESCRIPTION
workspace has compatibility issue in sougou explorer with fast mode

chinese：viewportpannel未设置height，低版本浏览器下子元素设置height:100%但父级未设置height，浏览器未能计算出父级的高度，导致模拟器高度异常，完全无法正常使用。在搜狗浏览器高速模式下可以复现（插入物料后进行选择等操作即可）