### PR TITLE
feat: add hasChildren parameter for DroppableWidget

### DIFF
--- a/formily/antd/src/components/ArrayCards/preview.tsx
+++ b/formily/antd/src/components/ArrayCards/preview.tsx
@@ -135,7 +135,7 @@ export const ArrayCards: DnFC<CardProps> = observer((props) => {
                   <TreeNodeWidget key={node.id} node={node} />
                 ))
               ) : (
-                <DroppableWidget />
+                <DroppableWidget hasChildren={false} />
               )}
             </div>
           </Card>

--- a/packages/react/src/widgets/DroppableWidget/index.tsx
+++ b/packages/react/src/widgets/DroppableWidget/index.tsx
@@ -16,14 +16,24 @@ export interface IDroppableWidgetProps {
   height?: number
   style?: React.CSSProperties
   className?: string
+  hasChildren?: boolean
 }
 
 export const DroppableWidget: React.FC<IDroppableWidgetProps> = observer(
-  ({ node, actions, height, placeholder, style, className, ...props }) => {
+  ({
+    node,
+    actions,
+    height,
+    placeholder,
+    style,
+    className,
+    hasChildren: hasChildrenProp,
+    ...props
+  }) => {
     const currentNode = useTreeNode()
     const nodeId = useNodeIdProps(node)
     const target = node ?? currentNode
-    const hasChildren = target.children?.length > 0
+    const hasChildren = hasChildrenProp ?? target.children?.length > 0
     return (
       <div {...nodeId} className={className} style={style}>
         {hasChildren ? (


### PR DESCRIPTION
为 `DroppableWidget` 添加 `hasChildren` 参数。这个参数可以解决有子节点时也希望渲染拖拽区域的情况。

比如：让 `ArrayCards` 在只有 `ArrayCards.` 开头的子元素时也能渲染拖拽区域

目前：

<img width="612" alt="image" src="https://user-images.githubusercontent.com/25266120/153553148-f6b735a8-dea8-4282-857e-e2658eed2160.png">

修改后：

<img width="621" alt="image" src="https://user-images.githubusercontent.com/25266120/153553375-0c789a7a-592f-4133-9c86-6382c74854a3.png">


_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/designable/blob/main/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `main`.
- [ ] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.
