### PR TITLE
fix(core): fix getClosestPosition error when component nesting

### DIFF
--- a/packages/core/src/models/MoveHelper.ts
+++ b/packages/core/src/models/MoveHelper.ts
@@ -111,12 +111,12 @@ export class MoveHelper {
     const closestNode = this.closestNode
     if (!closestNode || !viewport.isPointInViewport(point))
       return ClosestPosition.Forbid
-    const closestRect = viewport.getValidNodeRect(closestNode)
+    let closestRect = viewport.getValidNodeRect(closestNode)
     const isInline = this.getClosestLayout(viewport) === 'horizontal'
     if (!closestRect) {
       return
     }
-    const isAfter = isNearAfter(
+    let isAfter = isNearAfter(
       point,
       closestRect,
       viewport.moveInsertionType === 'block' ? false : isInline
@@ -132,7 +132,14 @@ export class MoveHelper {
           const parentClosestNode = getValidParent(closestNode)
           if (parentClosestNode) {
             this.closestNode = parentClosestNode
+            closestRect = viewport.getValidNodeRect(this.closestNode)
+            isAfter = isNearAfter(
+              point,
+              closestRect,
+              viewport.moveInsertionType === 'block' ? false : isInline
+            )
           }
+
           if (isInline) {
             if (parentClosestNode) {
               if (isAfter) {
@@ -177,9 +184,17 @@ export class MoveHelper {
     } else {
       if (!closestNode.allowSibling(this.dragNodes)) {
         const parentClosestNode = getValidParent(closestNode)
+
         if (parentClosestNode) {
           this.closestNode = parentClosestNode
+          closestRect = viewport.getValidNodeRect(this.closestNode)
+          isAfter = isNearAfter(
+            point,
+            closestRect,
+            viewport.moveInsertionType === 'block' ? false : isInline
+          )
         }
+
         if (isInline) {
           if (parentClosestNode) {
             if (isAfter) {


### PR DESCRIPTION
**问题**

当组件嵌套了多个组件时，会发生 closestPosition 计算不对的问题

拿Card 举例，在 behavior 里设置了 Card 不能 append 到 Card

![image](https://user-images.githubusercontent.com/6290186/162580720-f08e4c64-7a92-4aaa-8bf9-681b205d26ab.png)

录制了一个 gif 图，拖拽滑动到子组件时光标位置计算不对。 拖拽到 input， textArea 和 password 分别发生了多次光标跳动，无法给予拖拽用户一个准确的预期

![chrome-capture-2022-3-9](https://user-images.githubusercontent.com/6290186/162580599-641952ea-f23d-41bd-bdb2-d2c9b38d3ac7.gif)

**原因**

getClosestPosition 方法做了 closestNode 的重计算（主要是 onMove 事件在方法外会修改 closestNode，所以重计算 closestNode 没有问题 ），但没有进行 isAfter 的重计算。


**修复后效果**
![chrome-capture-2022-3-23](https://user-images.githubusercontent.com/6290186/164838528-cafac643-1eec-40e8-a5f7-bfc185d49e38.gif)



- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/designable/blob/main/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `main`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.


