### PR TITLE
fix(core):fix ArrayTable.Column insert non Column type node error

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: aslafy-z/conventional-pr-title-action@master
+      - uses: aslafy-z/conventional-pr-title-action@main
         with:
           preset: conventional-changelog-angular@^5.0.6
         env:

--- a/packages/core/src/models/TreeNode.ts
+++ b/packages/core/src/models/TreeNode.ts
@@ -571,8 +571,14 @@ export class TreeNode {
     if (parent?.children?.length) {
       const originSourceParents = nodes.map((node) => node.parent)
       const newNodes = this.resetNodesParent(nodes, parent)
+      if (
+        this.props.type === 'void' &&
+        this.props['x-component'] === 'ArrayTable.Column' &&
+        newNodes[0].props['x-component'] !== 'ArrayTable.Column'
+      ) {
+        return []
+      }
       if (!newNodes.length) return []
-
       return this.triggerMutation(
         new InsertAfterEvent({
           originSourceParents,
@@ -601,6 +607,13 @@ export class TreeNode {
     if (parent?.children?.length) {
       const originSourceParents = nodes.map((node) => node.parent)
       const newNodes = this.resetNodesParent(nodes, parent)
+      if (
+        this.props.type === 'void' &&
+        this.props['x-component'] === 'ArrayTable.Column' &&
+        newNodes[0].props['x-component'] !== 'ArrayTable.Column'
+      ) {
+        return []
+      }
       if (!newNodes.length) return []
       return this.triggerMutation(
         new InsertBeforeEvent({


### PR DESCRIPTION
bug : if insert a non-Array.Column type node into an Array.Column type node while use ArrayTable ,will get an error .
fix :  update TreeNode insert method , supplementary if judgment .
