### PR TITLE
fix:修复shadowroot存在时 attachShadow报错

### DIFF
--- a/packages/react/src/widgets/IconWidget/index.tsx
+++ b/packages/react/src/widgets/IconWidget/index.tsx
@@ -131,7 +131,7 @@ IconWidget.ShadowSVG = (props) => {
   const width = isNumSize(props.width) ? `${props.width}px` : props.width
   const height = isNumSize(props.height) ? `${props.height}px` : props.height
   useEffect(() => {
-    if (ref.current) {
+    if (ref.current && !ref.current.shadowRoot) {
       const root = ref.current.attachShadow({
         mode: 'open',
       })


### PR DESCRIPTION
error:  DOMException: Failed to execute 'attachShadow' on 'Element': Shadow root cannot be created on a host which already hosts a shadow tree.
    at http://localhost:5173/node_modules/.vite/deps/chunk-FTY4HS2E.js?v=dfb80248:989:36
    at commitHookEffectListMount (http://localhost:5173/node_modules/.vite/deps/chunk-PCJYLDI2.js?v=dfb80248:16904:34)
    at invokePassiveEffectMountInDEV (http://localhost:5173/node_modules/.vite/deps/chunk-PCJYLDI2.js?v=dfb80248:18320:19)
    at invokeEffectsInDev (http://localhost:5173/node_modules/.vite/deps/chunk-PCJYLDI2.js?v=dfb80248:19697:19)
    at commitDoubleInvokeEffectsInDEV (http://localhost:5173/node_modules/.vite/deps/chunk-PCJYLDI2.js?v=dfb80248:19682:15)
    at flushPassiveEffectsImpl (http://localhost:5173/node_modules/.vite/deps/chunk-PCJYLDI2.js?v=dfb80248:19499:13)
    at flushPassiveEffects (http://localhost:5173/node_modules/.vite/deps/chunk-PCJYLDI2.js?v=dfb80248:19443:22)
    at performSyncWorkOnRoot (http://localhost:5173/node_modules/.vite/deps/chunk-PCJYLDI2.js?v=dfb80248:18864:11)
    at flushSyncCallbacks (http://localhost:5173/node_modules/.vite/deps/chunk-PCJYLDI2.js?v=dfb80248:9135:30)
    at commitRootImpl (http://localhost:5173/node_modules/.vite/deps/chunk-PCJYLDI2.js?v=dfb80248:19428:11)
